### PR TITLE
Fix ImportError during setup

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc="Argon One Service and Control Scripts"
 arch=('any')
 url='https://download.argon40.com/argon1.sh'
 license=('GPL3')
-depends=('i2c-tools' 'lm_sensors' 'python>=3.3')
+depends=('i2c-tools' 'libffi' 'lm_sensors' 'python>=3.3')
 provides=('argonone')
 install=argonone.install
 


### PR DESCRIPTION
ImportError: libffi.so.7: cannot open shared object file: No such file or directory